### PR TITLE
box conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 packer_cache/
 builds/*
 !builds/.gitkeep
+src/.vagrant

--- a/src/Vagrantfile
+++ b/src/Vagrantfile
@@ -4,6 +4,7 @@
 Vagrant.configure("2") do |config|
   # Use Vagrant's default insecure key
   config.ssh.insert_key = false
+  config.vm.box = "fortinet-fortigate"
   # Set timeout to 3 mins
   config.vm.boot_timeout = 180
   # Disable default host <-> guest synced folder


### PR DESCRIPTION
When multiple box definitions are defined in the vagrant store, `vagrant up` doesnt know which box to install based on the current vagrant file, so I added a box name to specify the selection, and added src/.vagrant to gitignore to ensure that vagrant working dir is exempted from git.